### PR TITLE
Initial version of the devroom for Big Data and Machine Learning

### DIFF
--- a/devrooms/bigdata_ml.md
+++ b/devrooms/bigdata_ml.md
@@ -1,0 +1,46 @@
+# Big Data y Machine Learning (v0.1)
+
+El objetivo de la devroom es dar un espacio para compartir
+experiencias y conocimientos entorno a Big Data y Machine Learning.
+
+Ya se han confirmado talleres y charlas que cubrirán toda la
+cadena de ingesta, transformación y explotación de grandes volúmenes de datos.
+
+Todas las herramientas que se utilicen durante la devroom serán
+software libre, y se hará especial enfásis en temas como el
+acceso abierto a los datos.
+
+## Comunidad o grupo que lo propone
+
+El grupo que impulsa está devroom está compuesto por:
+
+* Juan Tomás García: Chief Envisioning Officer at Sngular & GDE for Cloud & ML
+* Israel Herráiz:  Strategic Cloud Engineer at Google
+* Alvaro del Castillo: Software Architect at Paradigma Digital
+
+Relacionados con los promotores se encuentran comunidad como la
+de Machine Learning Spain Meetup.
+
+## Público objetivo
+
+El público objetivo son perfiles técnicos que quieran recibir una
+introducción a Big Data y Machine Learning, incluyendo los principales
+proyectos y comunidades FLOSS en el campo, tanto los que proporcionan
+las tecnología como los que las usan.
+
+## Tiempo
+
+Es probable que se pueda necesitar un día completo para dar cabida a todas
+las contribuciones, pero se podría ajustar a medio día.
+
+## Formato
+
+El formato de la devroom incluirá:
+
+* Talleres
+* Charlas relámpago
+* Charlas plenarias
+* Mesas redondas
+
+La llamada a la participación se hará utilizando las redes sociales, redes
+específicas como Meetup, listas de distribución y otras vías.


### PR DESCRIPTION
# Big Data and Machine Learning DevRoom

# Se trata de una

* [ ] Charla/tutorial/charla relámpago
* [X] Devroom

# Personas que la proponen

* Juan Tomás García: Chief Envisioning Officer at Sngular & GDE for Cloud & ML
* Israel Herráiz:  Strategic Cloud Engineer at Google
* Alvaro del Castillo: Software Architect at Paradigma Digital

# Condiciones

* [X] Acepto coordinarme con la organización de esLibre.
* [X] Entiendo que si no hay un programa terminado para la fecha que establezca la organización, la *devroom* podría retirarse.
* [X] Acepto seguir el [código de conducta](https://eslib.re/2019/conducta/) y solicitar a los asistentes y ponentes esta aceptación.
* [X] Al menos una persona entre los que la proponen estará presente en Granada el día 21 junio de 2019.
